### PR TITLE
fix: Use git directory parent for absolute file paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export function main(
        * Read the modified file contents and resolve the relevant formatter.
        */
       const modifiedFile = new ModifiedFile({
-        fullPath: join(workingDirectory, filename),
+        fullPath: join(gitDirectoryParent, filename),
         gitDirectoryParent,
         base: options.base,
         head: options.head,


### PR DESCRIPTION
If you have a package.json file in a non-git-root directory you will get duplicate folders in the
path (since diffs are based at the git-root directory). This commit uses git root directory as path
base instead of working directory to fix that.

fix #3